### PR TITLE
Add LLM routing via OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This project demonstrates a simple autonomous agent using **LangGraph** to
 route user questions to external tools and **Gradio** for a minimal web
-interface.
+interface. An LLM determines which tool to call using OpenAI function
+calling.
 
 Two placeholder tools are included:
 
@@ -26,5 +27,8 @@ Then start the interface:
 python -m app.main
 ```
 
-Enter your question in the textbox. Mention **CRM** or **SCM** in the text to
-route the call explicitly; otherwise the CRM tool is used by default.
+Set the `OPENAI_API_KEY` environment variable before running so the agent can
+access the OpenAI API.
+
+Enter your question in the textbox. The LLM will decide whether to call the
+`crm_tool` or `scm_tool` based on your request.

--- a/app/agent_flow.py
+++ b/app/agent_flow.py
@@ -3,20 +3,70 @@
 from __future__ import annotations
 
 from typing import Dict, Any
+import os
+
+import openai
 from langgraph.graph import StateGraph, END
 
 from tools.crm_tool import crm_tool
 from tools.scm_tool import scm_tool
+from tools.retry import retry_async
+
+
+FUNCTIONS = [
+    {
+        "name": "crm_tool",
+        "description": "Query the CRM (SalesForce) system",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Question from the user to send to the CRM API",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "scm_tool",
+        "description": "Query the SCM (o9) system",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Question from the user to send to the SCM API",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+]
 
 
 async def router(state: Dict[str, Any]) -> str:
-    """Decide which tool to call based on user input."""
-    user_input = state.get("user_input", "").lower()
-    if "crm" in user_input:
-        return "crm"
-    if "scm" in user_input:
-        return "scm"
-    # default route: choose CRM
+    """Use an LLM to decide which tool to call."""
+    user_input = state.get("user_input", "")
+
+    async def _call_openai(messages):
+        return await openai.ChatCompletion.acreate(
+            model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo-0613"),
+            messages=messages,
+            functions=FUNCTIONS,
+            function_call="auto",
+        )
+
+    messages = [{"role": "user", "content": user_input}]
+    response = await retry_async(_call_openai, messages=messages)
+    choice = response.choices[0]
+    if choice.finish_reason == "function_call" and choice.message.function_call:
+        name = choice.message.function_call.name
+        if name == "crm_tool":
+            return "crm"
+        if name == "scm_tool":
+            return "scm"
+    # default route: choose CRM if no function call is produced
     return "crm"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 langgraph
 gradio
+openai


### PR DESCRIPTION
## Summary
- let an OpenAI LLM choose which tool to call
- include retry logic for OpenAI requests
- document OpenAI requirement
- add `openai` to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -c "import app.main; print('import ok')"` *(fails: ModuleNotFoundError: No module named 'gradio')*

------
https://chatgpt.com/codex/tasks/task_e_6848ed3b9c4c832e8ffdb10cdbb501a0